### PR TITLE
[J179] issue model 추가

### DIFF
--- a/server/models/comment.js
+++ b/server/models/comment.js
@@ -22,7 +22,7 @@ class CommentModel {
     );
   }
 
-  static async delete({ commentId }) {
+  static delete({ commentId }) {
     return db.comment.destroy({ where: { id: commentId } });
   }
 }

--- a/server/models/issue.js
+++ b/server/models/issue.js
@@ -10,8 +10,11 @@ class IssueModel {
     return db.issue.findAll({ where: { repositoryId } })
   }
 
-  static readIssueDetail() {
-
+  static readIssueDetail({ repositoryId, issueNumber }) {
+    return db.issue.findOne({
+      where: { issueNumber, repositoryId },
+      attributes: ['id', 'title', 'description', 'issueNumber', 'milestone_id', 'repository_id', 'createdAt', 'updatedAt', 'closedAt', 'author']
+    })
   }
 
   static updateIssueDetail() {

--- a/server/models/issue.js
+++ b/server/models/issue.js
@@ -3,11 +3,11 @@ const { update } = require('./comment');
 
 class IssueModel {
   static create(issueData) {
-    //title,description,issueNumber,author,milestoneId,repositoryId
+    //issueData: title,description,issueNumber,author,milestoneId,repositoryId
     return db.issue.create(issueData)
   }
 
-  static readIssueList({ repositoryId }) {
+  static readIssueList(repositoryId) {
     return db.issue.findAll({ where: { repositoryId } })
   }
 
@@ -18,7 +18,8 @@ class IssueModel {
     })
   }
 
-  static updateIssueDetail({ repositoryId, updateIssueData }) {
+  static updateIssueDetail( repositoryId, updateIssueData ) {
+    //updateIssueData: id, title, description, milestoneId
     return db.issue.update(
       {
         title: updateIssueData.title,
@@ -29,7 +30,8 @@ class IssueModel {
     )
   }
 
-  static updateOpenState({ repositoryId, stateData }) {
+  static updateOpenState( repositoryId, stateData ) {
+    //stateData: id, open
     if (stateData.open) {
       return db.issue.update(
         {
@@ -40,7 +42,6 @@ class IssueModel {
         }
       )
     }
-    console.log(stateData)
     return db.issue.update(
       { closedAt: new Date().toISOString().slice(0, 19).replace('T', ' ') },
       { where: { repositoryId, issueNumber: stateData.id } }

--- a/server/models/issue.js
+++ b/server/models/issue.js
@@ -29,6 +29,23 @@ class IssueModel {
     )
   }
 
-  static updateOpenState() {
+  static updateOpenState({ repositoryId, stateData }) {
+    if (stateData.open) {
+      return db.issue.update(
+        {
+          closedAt: null
+        },
+        {
+          where: { repositoryId, issueNumber: stateData.id }
+        }
+      )
+    }
+    console.log(stateData)
+    return db.issue.update(
+      { closedAt: new Date().toISOString().slice(0, 19).replace('T', ' ') },
+      { where: { repositoryId, issueNumber: stateData.id } }
+    )
   }
 }
+
+module.exports = IssueModel;

--- a/server/models/issue.js
+++ b/server/models/issue.js
@@ -1,51 +1,41 @@
 const db = require('../db/models');
-const { update } = require('./comment');
 
 class IssueModel {
   static create(issueData) {
-    //issueData: title,description,issueNumber,author,milestoneId,repositoryId
-    return db.issue.create(issueData)
+    // issueData: title,description,issueNumber,author,milestoneId,repositoryId
+    return db.issue.create(issueData);
   }
 
   static readIssueList(repositoryId) {
-    return db.issue.findAll({ where: { repositoryId } })
+    return db.issue.findAll({ where: { repositoryId } });
   }
 
-  static readIssueDetail({ repositoryId, issueNumber }) {
+  static readIssueDetail(repositoryId, issueNumber) {
     return db.issue.findOne({
       where: { issueNumber, repositoryId },
-      attributes: ['id', 'title', 'description', 'issueNumber', 'milestone_id', 'repository_id', 'createdAt', 'updatedAt', 'closedAt', 'author']
-    })
+    });
   }
 
-  static updateIssueDetail( repositoryId, updateIssueData ) {
-    //updateIssueData: id, title, description, milestoneId
+  static updateIssueDetail(repositoryId, issueNumber, updateIssueData) {
+    // updateIssueData:  title, description, milestoneId
     return db.issue.update(
       {
         title: updateIssueData.title,
         description: updateIssueData.description,
-        milestone_id: updateIssueData.milestoneId
+        milestoneId: updateIssueData.milestoneId,
       },
-      { where: { repositoryId, issueNumber: updateIssueData.id } }
-    )
+      { where: { repositoryId, issueNumber } }
+    );
   }
 
-  static updateOpenState( repositoryId, stateData ) {
-    //stateData: id, open
-    if (stateData.open) {
-      return db.issue.update(
-        {
-          closedAt: null
-        },
-        {
-          where: { repositoryId, issueNumber: stateData.id }
-        }
-      )
-    }
+  static updateOpenState(repositoryId, issueNumber, isOpen) {
+    const openState = isOpen
+      ? null
+      : new Date().toISOString().slice(0, 19).replace('T', ' ');
     return db.issue.update(
-      { closedAt: new Date().toISOString().slice(0, 19).replace('T', ' ') },
-      { where: { repositoryId, issueNumber: stateData.id } }
-    )
+      { closedAt: openState },
+      { where: { repositoryId, issueNumber } }
+    );
   }
 }
 

--- a/server/models/issue.js
+++ b/server/models/issue.js
@@ -1,4 +1,5 @@
 const db = require('../db/models');
+const { update } = require('./comment');
 
 class IssueModel {
   static create(issueData) {
@@ -17,12 +18,17 @@ class IssueModel {
     })
   }
 
-  static updateIssueDetail() {
-
+  static updateIssueDetail({ repositoryId, updateIssueData }) {
+    return db.issue.update(
+      {
+        title: updateIssueData.title,
+        description: updateIssueData.description,
+        milestone_id: updateIssueData.milestoneId
+      },
+      { where: { repositoryId, issueNumber: updateIssueData.id } }
+    )
   }
 
   static updateOpenState() {
   }
 }
-
-module.exports = IssueModel;

--- a/server/models/issue.js
+++ b/server/models/issue.js
@@ -6,8 +6,8 @@ class IssueModel {
     return db.issue.create(issueData)
   }
 
-  static readIssueList() {
-
+  static readIssueList({ repositoryId }) {
+    return db.issue.findAll({ where: { repositoryId } })
   }
 
   static readIssueDetail() {

--- a/server/models/issue.js
+++ b/server/models/issue.js
@@ -1,0 +1,25 @@
+const db = require('../db/models');
+
+class IssueModel {
+  static create(issueData) {
+    //title,description,issueNumber,author,milestoneId,repositoryId
+    return db.issue.create(issueData)
+  }
+
+  static readIssueList() {
+
+  }
+
+  static readIssueDetail() {
+
+  }
+
+  static updateIssueDetail() {
+
+  }
+
+  static updateOpenState() {
+  }
+}
+
+module.exports = IssueModel;


### PR DESCRIPTION
- 각 메소드 추가
  - create : issueData의 정보들로 새로운 이슈 생성
  - readIssueList: 해당 아이디의 repository의 이슈 전부 반환
  - readIssueDetail: 해당 아이디, 이슈넘버의 이슈 정보 반환
  - updateIssueDetail: 해당 아이디의 repository의 이슈 중에서 updateIssueData내의 id를 issueNumber로 가지는 이슈의 정보 수정
  - updateOpenState: 해당 아이디의 repository의 이슈 중에서 stateData내의 id를 issueNumber로 가지는 이슈의 open 상태 수정
  (open이면 closed_at을 null로, false면 현재 시각으로 값 수정. )