### PR TITLE
[J054] 동일한 name의 label 검증 버그 수정

### DIFF
--- a/server/models/label.js
+++ b/server/models/label.js
@@ -1,3 +1,4 @@
+const { Op } = require('sequelize');
 const db = require('../db/models').label;
 
 class LabelModel {
@@ -11,9 +12,15 @@ class LabelModel {
     });
   }
 
-  static findLabelByName(name) {
+  static findLabelByName(name, repositoryId, labelId = null) {
     return db.findOne({
-      where: { name },
+      where: {
+        name,
+        repositoryId,
+        id: {
+          [Op.not]: labelId,
+        },
+      },
     });
   }
 

--- a/server/models/label.js
+++ b/server/models/label.js
@@ -12,7 +12,7 @@ class LabelModel {
     });
   }
 
-  static findLabelByName(name, repositoryId, labelId = null) {
+  static findByName(name, repositoryId, labelId = null) {
     return db.findOne({
       where: {
         name,

--- a/server/services/label.js
+++ b/server/services/label.js
@@ -46,11 +46,7 @@ class LabelService {
   }
 
   static async isDuplicatedName(name, repositoryId, labelId) {
-    const foundLabel = await LabelModel.findLabelByName(
-      name,
-      repositoryId,
-      labelId
-    );
+    const foundLabel = await LabelModel.findByName(name, repositoryId, labelId);
     if (foundLabel === null) return false;
     return true;
   }

--- a/server/services/label.js
+++ b/server/services/label.js
@@ -2,7 +2,12 @@ const LabelModel = require('../models/label');
 
 class LabelService {
   static async create(labelData) {
-    if (await LabelService.isDuplicatedName(labelData.name))
+    if (
+      await LabelService.isDuplicatedName(
+        labelData.name,
+        labelData.repositoryId
+      )
+    )
       throw Error('title has already been taken');
     const newLabel = await LabelModel.create(labelData);
     return { id: newLabel.id };
@@ -23,7 +28,13 @@ class LabelService {
   }
 
   static async update(labelData) {
-    if (await LabelService.isDuplicatedName(labelData.name))
+    if (
+      await LabelService.isDuplicatedName(
+        labelData.name,
+        labelData.repositoryId,
+        labelData.id
+      )
+    )
       throw Error('title has already been taken');
     const [count] = await LabelModel.update(labelData);
     return count === 0 ? null : { id: labelData.id };
@@ -34,8 +45,12 @@ class LabelService {
     return deletedCount === 0 ? null : { id: labelId };
   }
 
-  static async isDuplicatedName(name) {
-    const foundLabel = await LabelModel.findLabelByName(name);
+  static async isDuplicatedName(name, repositoryId, labelId) {
+    const foundLabel = await LabelModel.findLabelByName(
+      name,
+      repositoryId,
+      labelId
+    );
     if (foundLabel === null) return false;
     return true;
   }

--- a/server/services/label.js
+++ b/server/services/label.js
@@ -45,7 +45,7 @@ class LabelService {
     return deletedCount === 0 ? null : { id: labelId };
   }
 
-  static async isDuplicatedName(name, repositoryId, labelId) {
+  static async isDuplicatedName(name, repositoryId, labelId = null) {
     const foundLabel = await LabelModel.findByName(name, repositoryId, labelId);
     if (foundLabel === null) return false;
     return true;


### PR DESCRIPTION
update할 때 본인의 name을 유지했을 때 중복된 name라는 error 반환하는 버그 발생해서 다음과 같이 수정
- 동일한 repository 안에서만 중복된 label 생성 불가하도록 수정
- update할 때 자기 자신의 name과는 동일해도 되기 때문에 id가 다른 label만 검증하도록 수정