### PR TITLE
[J179] Issue model에 다른 테이블 참조 기능 구현

### DIFF
--- a/server/db/models/issue.js
+++ b/server/db/models/issue.js
@@ -9,14 +9,14 @@ module.exports = (sequelize, DataTypes) => {
      */
     static associate(models) {
       // define association here
-      models.issue.hasMany(models.comment, { foreignKey: 'author' });
+      models.issue.hasMany(models.comment);
+      models.issue.belongsTo(models.milestone, { foreignKey: 'milestone_id' });
       models.issue.belongsToMany(models.label, {
         through: 'issue_label',
-        foreignKey: 'issueId',
       });
       models.issue.belongsToMany(models.user, {
         through: 'assignee',
-        foreignKey: 'issueId',
+        as: 'assignees',
       });
     }
   }

--- a/server/models/issue.js
+++ b/server/models/issue.js
@@ -7,12 +7,34 @@ class IssueModel {
   }
 
   static readIssueList(repositoryId) {
-    return db.issue.findAll({ where: { repositoryId } });
+    return db.issue.findAll({
+      where: { repositoryId },
+      include: [
+        { model: db.label, attributes: ['id', 'name', 'color'] },
+        {
+          model: db.user,
+          attributes: ['id', 'userName', 'profile_url'],
+          as: 'assignees',
+        },
+        db.comment,
+        db.milestone,
+      ],
+    });
   }
 
   static readIssueDetail(repositoryId, issueNumber) {
     return db.issue.findOne({
       where: { issueNumber, repositoryId },
+      include: [
+        { model: db.label, attributes: ['id', 'name', 'color'] },
+        {
+          model: db.user,
+          attributes: ['id', 'userName', 'profile_url'],
+          as: 'assignees',
+        },
+        db.comment,
+        db.milestone,
+      ],
     });
   }
 

--- a/server/models/issue.js
+++ b/server/models/issue.js
@@ -50,6 +50,20 @@ class IssueModel {
     );
   }
 
+  static async setAssignees(issueId, assignees) {
+    const foundUsers = await db.user.findAll({ where: { id: assignees } });
+    const issue = await db.issue.findOne({ where: { id: issueId } });
+    const resultArray = await issue.setAssignees(foundUsers);
+    return resultArray;
+  }
+
+  static async setLabels(issueId, labels) {
+    const foundlabels = await db.label.findAll({ where: { id: labels } });
+    const issue = await db.issue.findOne({ where: { id: issueId } });
+    const resultArray = await issue.setLabels(foundlabels);
+    return resultArray;
+  }
+
   static updateOpenState(repositoryId, issueNumber, isOpen) {
     const openState = isOpen
       ? null

--- a/server/models/milestone.js
+++ b/server/models/milestone.js
@@ -50,4 +50,3 @@ class MilestoneModel {
 }
 
 module.exports = MilestoneModel;
-


### PR DESCRIPTION
- assignee(user), label, milestone, comment 참조를 위한 관계 정의 수정
  - 외래키 삭제
  - alias로 users->assignees로 필드명 변경
  - milestone 관계 설정 누락된 부분 추가

- issue model에 create,update,read 시 다른 테이블의 데이터도 생성, 변경, 읽을 수 있도록 기능 추가