### PR TITLE
[J003] 리스트로 만들어주는 List.jsx 추가

### DIFF
--- a/client/src/components/IssueListHeader.jsx
+++ b/client/src/components/IssueListHeader.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import DefaultButton from './DefaultButton';
-import DropdownCaret from './.components/DropdownCaret';
+import DropdownCaret from './DropdownCaret';
 
 const FlexContainer = styled.div`
   display: flex;

--- a/client/src/components/List.jsx
+++ b/client/src/components/List.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+
+const ListContainer = styled.div`
+  border: 1px solid;
+  border-color: #d1d5da;
+  display: block;
+  padding-left: 0;
+  ${(props) =>
+    css`
+      border-radius: ${props.borderRadius};
+    `}
+`;
+const ListConetentContainer = styled.ul`
+  padding: 0;
+  margin: 0;
+`;
+const ListBoxContainer = styled.li`
+  display: flex;
+  list-style: none;
+  border-top: 1px solid;
+  border-color: #d1d5da;
+`;
+
+const List = (props) => {
+  const contentList = () =>
+    props.content.map((content, i) => (
+      <ListBoxContainer key={i}>{content}</ListBoxContainer>
+    ));
+
+  return (
+    <ListContainer borderRadius={props.borderRadius}>
+      {props.header}
+      <ListConetentContainer>
+        {props.content ? contentList() : props.emptyComponent}
+      </ListConetentContainer>
+    </ListContainer>
+  );
+};
+
+export default List;

--- a/client/src/components/MilestoneContent.jsx
+++ b/client/src/components/MilestoneContent.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 
-const MilestoneStyle = styled.li`
+const MilestoneStyle = styled.div`
   font-size: 14px;
   line-height: 14px;
   box-sizing: border-box;


### PR DESCRIPTION
원하는 헤더, 배열이 없을시의 페이지,  배열로 만들어진 컴포넌트를 props로 넘겨주면 이에 맞춰서 리스트로 만들어주는 컴포넌트

헤더를 넣어주면 헤더를 포함

배열이 없을시의 컴포넌트를 넣어주면 해당 컴포넌트로 출력

배열로 만들어진 컴포넌트를 넣어주면 해당 컴포넌트를 리스트로 만들어줌

만들어진 리스트를 border-radius를 인자로 넘길  수 있도록 설정 