### PR TITLE
[J054] Filter 두번 클릭해야 화면 전환되는 버그 수정

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "webpack-dev-server --mode development",
+    "start": "webpack-dev-server --mode development -w --watch-poll",
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "webpack --mode production"
   },

--- a/client/src/components/IssueListNav.jsx
+++ b/client/src/components/IssueListNav.jsx
@@ -67,8 +67,9 @@ const IssueListNav = (props) => {
   const filterClickHandler = (e) => {
     document.getElementById('searchBar').value = e.target.dataset.searchInput;
     setQuerySubmitted(true);
-    setQuery(props.location.search);
     closeDropdownHandler();
+    const { href } = e.target;
+    setQuery(href.slice(href.indexOf('?')));
   };
 
   return (

--- a/client/src/components/issueList/IssueContent.jsx
+++ b/client/src/components/issueList/IssueContent.jsx
@@ -46,7 +46,6 @@ const CheckboxStateContainer = styled.span`
 const CheckboxContainer = styled.div``;
 const IssueContent = ({ data }) => {
   const assigneesData = data.assignees;
-  console.log(data);
   const stateSvg = () =>
     data.closdAt ? (
       <Svg


### PR DESCRIPTION
FilterMenu는 Link로 만들어져서 클릭하면 url에 query params를 직접 삽입해서 변경하는 것이 아니라
location.search로 query 가져오면 나중에 가져와지므로 href를 직접 파싱해서 query만 뽑아내서 변하도록 함